### PR TITLE
Fix Armsom Forge1 to allow luckfox-config mipi display selecton

### DIFF
--- a/kernel-6.1/arch/arm/boot/dts/rk3506-armsom-forge1.dts
+++ b/kernel-6.1/arch/arm/boot/dts/rk3506-armsom-forge1.dts
@@ -246,8 +246,17 @@
 };
 
 /**********usb**********/
+
 &usb20_otg0 {
-	dr_mode = "peripheral";
+	status = "okay";
+};
+
+&u2phy_otg1 {
+    phy-supply = <&vcc5v0_otg1>;
+	status = "okay";
+};
+
+&usb2phy {
 	status = "okay";
 };
 
@@ -255,7 +264,6 @@
 	dr_mode = "host";
 	status = "okay";
 };
-
 
 /**********pinctrl**********/
 &pinctrl {


### PR DESCRIPTION
requires updated luckfox-config - https://github.com/markbirss/rk3506-ubuntu/releases/tag/1.1