### PR TITLE
Re-enable usb adb mode for Luckfox Lyra Pi board

### DIFF
--- a/kernel-6.1/arch/arm/boot/dts/rk3506b-luckfox-lyra-pi-w-sd.dts
+++ b/kernel-6.1/arch/arm/boot/dts/rk3506b-luckfox-lyra-pi-w-sd.dts
@@ -173,7 +173,7 @@
 };
 
 &usb20_otg1 {
-	dr_mode = "otg";
+	dr_mode = "host";
 	status = "okay";
 };
 

--- a/kernel-6.1/arch/arm/boot/dts/rk3506b-luckfox-lyra-pi-w.dts
+++ b/kernel-6.1/arch/arm/boot/dts/rk3506b-luckfox-lyra-pi-w.dts
@@ -171,7 +171,7 @@
 };
 
 &usb20_otg1 {
-	dr_mode = "otg";
+	dr_mode = "host";
 	status = "okay";
 };
 


### PR DESCRIPTION
&usb20_otg1 {
	dr_mode = "otg";
	status = "okay";
};

vs

&usb20_otg1 {
        dr_mode = "host";
        status = "okay";
};